### PR TITLE
LPS-80356 Check if field is localizable before call addAvailableLanguageIds

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -768,9 +768,12 @@ AUI.add(
 
 							fieldJSON.value = instance.get('localizationMap');
 
-							var form = instance.getForm();
+							if (instance.get('localizable')) {
+								var form = instance.getForm();
 
-							form.addAvailableLanguageIds(AObject.keys(fieldJSON.value));
+								form.addAvailableLanguageIds(AObject.keys(fieldJSON.value));
+							}
+
 						}
 
 						var fields = instance.get('fields');


### PR DESCRIPTION
Hey @SpencerWoo Can you check if this fix works in IE11? I think checking that the field is localizable is enough to fix this problem, at least in master.

Thx

//cc @jonathanmccann