### PR TITLE
Lps 82667

### DIFF
--- a/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/configuration/UserFileUploadsConfiguration.java
+++ b/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/configuration/UserFileUploadsConfiguration.java
@@ -36,13 +36,13 @@ public interface UserFileUploadsConfiguration {
 	public long imageMaxSize();
 
 	@Meta.AD(
-		deflt = "120", description = "users-image-maximum-height-help",
+		deflt = "290", description = "users-image-maximum-height-help",
 		name = "maximum-height", required = false
 	)
 	public int imageMaxHeight();
 
 	@Meta.AD(
-		deflt = "100", description = "users-image-maximum-width-help",
+		deflt = "290", description = "users-image-maximum-width-help",
 		name = "maximum-width", required = false
 	)
 	public int imageMaxWidth();

--- a/modules/apps/users-admin/users-admin-api/src/main/resources/com/liferay/users/admin/configuration/packageinfo
+++ b/modules/apps/users-admin/users-admin-api/src/main/resources/com/liferay/users/admin/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.0.1


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82667

I'm unaware of a good reason to keep 120x100.  It's true these properties can be set by users however with OOTB the Site Memership View Icon is almost always larger than 120x100 which causes the image to be stretched.

There doesn't seem to be a hard number value for the icon size (https://lexicondesign.io/docs/designPrinciples/layout/layoutCards.html) but the largest I've observed is 287.83 so I've chosen 290 as the default value.