### PR TITLE
LPS-85955 Fixed unescaped file and folder names in DL

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -126,6 +126,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 					}
 
 					String thumbnailSrc = DLUtil.getThumbnailSrc(fileEntry, latestFileVersion, themeDisplay);
+					latestFileVersion = latestFileVersion.toEscapedModel();
 					%>
 
 					<c:choose>
@@ -440,7 +441,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									cssClass="table-cell-expand table-cell-minw-200 table-title"
 									href="<%= rowURL %>"
 									name="title"
-									value="<%= curFolder.getName() %>"
+									value="<%= HtmlUtil.escape(curFolder.getName()) %>"
 								/>
 							</c:if>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
@@ -66,6 +66,7 @@ PortletURL rowURL = liferayPortletResponse.createRenderURL();
 rowURL.setParameter("mvcRenderCommandName", "/document_library/view_file_entry");
 rowURL.setParameter("redirect", HttpUtil.removeParameter(currentURL, liferayPortletResponse.getNamespace() + "ajax"));
 rowURL.setParameter("fileEntryId", String.valueOf(fileEntry.getFileEntryId()));
+latestFileVersion = latestFileVersion.toEscapedModel();
 %>
 
 <h5 class="text-default">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-85955

Set `latestFileVersion` to `latestFileVersion.toEscapedModel()` to fix. Escaped folder title in table view.