### PR TITLE
LPS-87969 Change HTTP request property to use 'off' instead of release name

### DIFF
--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -1303,7 +1303,7 @@ public class MainServlet extends HttpServlet {
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_DEFAULT =
 		StringUtil.equalsIgnoreCase(
-			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, ReleaseInfo.getName());
+			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, "off");
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_PARTIAL =
 		StringUtil.equalsIgnoreCase(

--- a/portal-impl/src/com/liferay/portal/linkback/LinkbackProducerUtil.java
+++ b/portal-impl/src/com/liferay/portal/linkback/LinkbackProducerUtil.java
@@ -249,7 +249,7 @@ public class LinkbackProducerUtil {
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_DEFAULT =
 		StringUtil.equalsIgnoreCase(
-			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, ReleaseInfo.getName());
+			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, "off");
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_PARTIAL =
 		StringUtil.equalsIgnoreCase(

--- a/portal-impl/src/com/liferay/portal/xmlrpc/XmlRpcImpl.java
+++ b/portal-impl/src/com/liferay/portal/xmlrpc/XmlRpcImpl.java
@@ -109,7 +109,7 @@ public class XmlRpcImpl implements XmlRpc {
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_DEFAULT =
 		StringUtil.equalsIgnoreCase(
-			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, ReleaseInfo.getName());
+			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, "off");
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_PARTIAL =
 		StringUtil.equalsIgnoreCase(


### PR DESCRIPTION
Relevant ticket: https://issues.liferay.com/browse/LPS-87969
Documentation: https://docs.liferay.com/ce/portal/7.0-latest/propertiesdoc/portal.properties.html#HTTP%20Header%20Response

The system property to detail the Liferay version as part of an HTTP request header currently has the following levels: "full", "partial", and the release name of the bundle. "full" adds the full bundle name, "partial" omits the Liferay-portal field in the response, and the bundle's release name disables the request header altogether. A more intuitive approach to turn off the HTTP request header would be to change the level from the release name to "off", which is done in this ticket.