### PR TITLE
LPS-87969 Change HTTP request property to use 'off' instead of release name

### DIFF
--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -1303,7 +1303,7 @@ public class MainServlet extends HttpServlet {
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_DEFAULT =
 		StringUtil.equalsIgnoreCase(
-			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, ReleaseInfo.getName());
+			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, "off");
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_PARTIAL =
 		StringUtil.equalsIgnoreCase(

--- a/portal-impl/src/com/liferay/portal/linkback/LinkbackProducerUtil.java
+++ b/portal-impl/src/com/liferay/portal/linkback/LinkbackProducerUtil.java
@@ -249,7 +249,7 @@ public class LinkbackProducerUtil {
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_DEFAULT =
 		StringUtil.equalsIgnoreCase(
-			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, ReleaseInfo.getName());
+			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, "off");
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_PARTIAL =
 		StringUtil.equalsIgnoreCase(

--- a/portal-impl/src/com/liferay/portal/xmlrpc/XmlRpcImpl.java
+++ b/portal-impl/src/com/liferay/portal/xmlrpc/XmlRpcImpl.java
@@ -109,7 +109,7 @@ public class XmlRpcImpl implements XmlRpc {
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_DEFAULT =
 		StringUtil.equalsIgnoreCase(
-			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, ReleaseInfo.getName());
+			PropsValues.HTTP_HEADER_VERSION_VERBOSITY, "off");
 
 	private static final boolean _HTTP_HEADER_VERSION_VERBOSITY_PARTIAL =
 		StringUtil.equalsIgnoreCase(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6699,11 +6699,8 @@
     # header response. Valid values are "full", which gives all of the version
     # information (e.g. Liferay Portal Community Edition 6.1.0 CE etc.),
     # "partial", which gives only the name portion (e.g. Liferay Portal
-    # Community Edition), or the default release name (e.g. "Liferay Portal
-    # Community Edition" or "Liferay Portal Enterprise Edition"), which prevents
-    # the Portal from adding the Liferay-Portal field in the HTTP header
-    # response. The default release name must match the Portal edition being
-    # used.
+    # Community Edition), or "off" which prevents the Portal from adding the
+    # Liferay-Portal field in the HTTP header response.
     #
     # Env: LIFERAY_HTTP_PERIOD_HEADER_PERIOD_VERSION_PERIOD_VERBOSITY
     #


### PR DESCRIPTION
Relevant ticket: https://issues.liferay.com/browse/LPS-87969

Conversation here: https://github.com/SpencerWoo/liferay-portal/pull/27
Note: not a bug, but this makes the property level names more intuitive. It would be fine to push this to master and include it in the next release.