### PR TITLE
LPS-88275

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/search/ConfigurationModelIndexer.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/search/ConfigurationModelIndexer.java
@@ -287,6 +287,10 @@ public class ConfigurationModelIndexer extends BaseIndexer<ConfigurationModel> {
 		Map<String, ConfigurationModel> configurationModels =
 			_configurationModelRetriever.getConfigurationModels();
 
+		_indexWriterHelper.deleteEntityDocuments(
+			getSearchEngineId(), CompanyConstants.SYSTEM, getClassName(),
+			isCommitImmediately());
+
 		for (ConfigurationModel configurationModel :
 				configurationModels.values()) {
 


### PR DESCRIPTION
Hey Spencer,
I've made a fix for LPS-88275, but I'd like for you to take a look at it before moving it along.  It worked fine on my end, but I'd like for you to double check.  Here's the explanation:

Background: The configurations are "stored" in two places.  The first is the ConfigurationModelRetriever class.  This is where we store the actual configuration for viewing and use.  The second is in the Elasticsearch index.  This is where we retrieve results when searching through configurations.

When we see the duplicated configuration entry, it's not that there is 2 configurations conflicting, but rather there are 2 configuration entries in ES.  This is why both configurations entries point to the same configuration, and modifying one updates "both" of them.

It's also important to note the ConfigurationModel class doesn't instantly index new/updated entries; it's only during a full reindex, single class reindex, or scheduled reindex of some sort the indices are updated in ES.

Why this is happening:  Typically, whenever we reindex any given class, we first delete all the entries within ES which match the classType of the reindex and in the given companyId (this is typically the default companyId).  This works for company-scoped assets, but won't affect portal-scoped assets, in which configurationModels fall in this realm.
However, this doesn't explain why other configuration types aside from LDAP reindex properly, but it does explain in part why we are seeing this behavior.  
When reindexing other ConfigurationModels, we see they are never duplicated.  This is because those ConfigurationModels are always updated, whereas the LDAP related ones are not.  LDAP related ConfigurationModels are appending with a unique identifier if they are modified.  So, when updating the index, it isn't found (since the UID is appending to the ConfigurationModel PID, and therefore is considered a new entry in ES) and instead a new index is added.  So, both the default and UID appending configurations exist with ES.

What the fix does:  It simply removes the ConfigurationModel entries within ES before adding in each one back in.  Instead of using the [default companyId to remove the entries from ES as we do before reindexing](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexSingleIndexerBackgroundTaskExecutor.java#L78), it also uses "0", which is the ID the entries are stored under.  This is specific for ConfigurationModel assets, so the change was placed in the ConfigurationModelIndexer class.

Let me know if you have any questions.  Thanks!