### PR TITLE
LPS-88889 Control if the file entry is in the recycle bin

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
@@ -247,6 +247,10 @@ public class DDMFormValuesExportImportContentProcessor
 				FileEntry fileEntry =
 					_dlAppService.getFileEntryByUuidAndGroupId(uuid, groupId);
 
+				if (fileEntry.isInTrash()) {
+					continue;
+				}
+
 				if (_exportReferencedContent) {
 					StagedModelDataHandlerUtil.exportReferenceStagedModel(
 						_portletDataContext, _stagedModel, fileEntry,


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPS-88889
https://issues.liferay.com/browse/LPP-32493

Issue: Having a web content reference (document in this case) in the recycle bin stops the import from going through. This was specified in [this PTR](https://issues.liferay.com/browse/PTR-551).

Solution: Since deleting a document from the recycle bin removes the reference from the web content, the only way that this error can be produced is if the document is in the recycle bin. Adding a check resolves that issue. 