### PR TITLE
LPS-90392 Add response to failed CaptchaTextException

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -92,7 +92,12 @@ public class AddFormInstanceRecordMVCActionCommand
 		DDMFormInstance ddmFormInstance =
 			_ddmFormInstanceService.getFormInstance(formInstanceId);
 
-		validateCaptcha(actionRequest, ddmFormInstance);
+		try {
+			validateCaptcha(actionRequest, ddmFormInstance);
+		}
+		catch (CaptchaTextException cte) {
+			return;
+		}
 
 		DDMForm ddmForm = getDDMForm(ddmFormInstance);
 


### PR DESCRIPTION
Relevant ticket:
https://issues.liferay.com/browse/LPS-90392

Issue: For forms with success pages, a failed captcha check redirects to the success page (but does not store the form in the database) because `AddFormInstanceRecordMVCActionCommand.validateCaptcha()` throws an exception that is not handled properly.

Solution: Added a try-catch loop to return and stop the `doProcessAction()` method if the Captcha failed.