### PR TITLE
LPS-99243 Remove <h1> tag from all themes

### DIFF
--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord-site-initializer/src/main/resources/com/liferay/frontend/theme/fjord/site/initializer/internal/dependencies/fragments/home/actions.html
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord-site-initializer/src/main/resources/com/liferay/frontend/theme/fjord/site/initializer/internal/dependencies/fragments/home/actions.html
@@ -4,7 +4,7 @@
 			<div class="row">
 				<div class="col-12 col-lg-8 col-md-10 col-xl-6">
 					<lfr-editable id="fjord-actions-title" type="rich-text">
-						<h1 class="display-4">Dynamic and Customizable for a Healthier You</h1>
+						<span class="display-4">Dynamic and Customizable for a Healthier You</span>
 					</lfr-editable>
 
 					<div class="lead">

--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/templates/portal_normal.ftl
@@ -20,7 +20,7 @@
 
 		<div class="mb-0 pt-0" id="wrapper">
 			<main id="content" role="main">
-				<h1 class="sr-only">${the_title}</h1>
+				<span class="sr-only">${the_title}</span>
 
 				<#if selectable>
 					<@liferay_util["include"] page=content_include />

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon-site-initializer/src/main/resources/com/liferay/frontend/theme/porygon/site/initializer/internal/dependencies/fragments/entry.html
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon-site-initializer/src/main/resources/com/liferay/frontend/theme/porygon/site/initializer/internal/dependencies/fragments/entry.html
@@ -9,9 +9,9 @@
 <div class="container-fluid container-fluid-max-xl container-form-lg">
 	<div class="row">
 		<div class="col-md-10 col-lg-8 mx-auto">
-			<h1 class="text-center">
+			<div class="text-center">
 				<lfr-editable id="porygon_detail_content_title" type="text">Title</lfr-editable>
-			</h1>
+			</div>
 
 			<h2 class="text-center">
 				<lfr-editable id="porygon_detail_content_subtitle" type="text">Sub title</lfr-editable>

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/src/templates/portal_normal.ftl
@@ -43,7 +43,7 @@
 			</#if>
 
 			<main id="content" role="main">
-				<h1 class="hide-accessible">${the_title}</h1>
+				<span class="hide-accessible">${the_title}</span>
 
 				<#if selectable>
 					<@liferay_util["include"] page=content_include />

--- a/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank-site-initializer/src/main/resources/com/liferay/frontend/theme/westeros/bank/site/initializer/internal/dependencies/fragments/links.html
+++ b/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank-site-initializer/src/main/resources/com/liferay/frontend/theme/westeros/bank/site/initializer/internal/dependencies/fragments/links.html
@@ -4,7 +4,7 @@
 			<div class="row">
 				<div class="col-12">
 					<lfr-editable id="westeros-links-title" type="rich-text">
-						<h1 class="h6 mb-0">FIND US</h1>
+						<span class="h6 mb-0">FIND US</span>
 					</lfr-editable>
 				</div>
 			</div>

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -30,7 +30,7 @@
 							<img alt="${logo_description}" class="mr-2" height="56" src="${site_logo}" />
 
 							<#if show_site_name>
-								<h1 class="font-weight-bold h2 mb-0 text-dark">${site_name}</h1>
+								<span class="font-weight-bold h2 mb-0 text-dark">${site_name}</span>
 							</#if>
 						</a>
 
@@ -57,7 +57,7 @@
 						<img alt="${logo_description}" class="mr-2" height="56" src="${site_logo}" />
 
 						<#if show_site_name>
-							<h1 class="font-weight-bold h2 mb-0 text-dark">${site_name}</h1>
+							<span class="font-weight-bold h2 mb-0 text-dark">${site_name}</span>
 						</#if>
 					</a>
 
@@ -68,7 +68,7 @@
 	</#if>
 
 	<section class="${portal_content_css_class}" id="content">
-		<h1 class="sr-only">${the_title}</h1>
+		<span class="sr-only">${the_title}</span>
 
 		<#if selectable>
 			<@liferay_util["include"] page=content_include />

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/navigation.ftl
@@ -1,5 +1,5 @@
 <nav class="${nav_css_class}" id="navigation" role="navigation">
-	<h1 class="hide-accessible"><@liferay.language key="navigation" /></h1>
+	<span class="hide-accessible"><@liferay.language key="navigation" /></span>
 
 	<ul aria-label="<@liferay.language key="site-pages" />" role="menubar">
 		<#list nav_items as nav_item>

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
@@ -23,7 +23,7 @@
 <div class="container-fluid" id="wrapper">
 	<header id="banner" role="banner">
 		<div id="heading">
-			<h1 class="site-title">
+			<div class="site-title">
 				<a class="${logo_css_class}" href="${site_default_url}" title="<@liferay.language_format arguments="${site_name}" key="go-to-x" />">
 					<img alt="${logo_description}" height="${site_logo_height}" src="${site_logo}" width="${site_logo_width}" />
 				</a>
@@ -33,7 +33,7 @@
 						${site_name}
 					</span>
 				</#if>
-			</h1>
+			</div>
 		</div>
 
 		<#if !is_signed_in>
@@ -46,7 +46,7 @@
 	</header>
 
 	<section id="content">
-		<h1 class="hide-accessible">${the_title}</h1>
+		<span class="hide-accessible">${the_title}</span>
 
 		<#if selectable>
 			<@liferay_util["include"] page=content_include />


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-99243

I simply replaced the `<h1>` tags with either a `<span>` or `<div>`, but I'm not positive that won't affect some styling. From first glance, it looks as though the `<h1>` tags were not used as the style selector, and only the class="??" was used, which leads me to believe that the styling would not be affected by the change. Not sure how to test fully though.